### PR TITLE
Add travis integration and mocha test skeleton

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,25 @@
+sudo: required
+
+language: node_js
+node_js:
+    - node
+
+services:
+    - docker
+
+branches:
+    except:
+        - gh-pages
+
+before_script:
+    - docker-compose build
+    - docker-compose up -d
+    - npm install --dev
+
+script:
+    - docker ps | grep omp-nodejs
+    - docker ps | grep omp-mongo
+    - npm test
+
+after_script:
+    - docker-compose down

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,13 @@
 FROM node:latest
 
-WORKDIR /home/omp
+RUN mkdir -p /omp
+WORKDIR /omp
 
 # Install app dependencies
-COPY ./package.json .
+COPY ./package.json ./package.json
 RUN npm install --production
 
 # Copy over the app files
-COPY . .
+COPY ./ ./
 
 CMD ["node", "server.js"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 omp-nodejs:
     build: .
-    working_dir: /home/omp
+    working_dir: /omp
     environment:
         NODE_ENV: development
     ports:

--- a/package.json
+++ b/package.json
@@ -7,5 +7,12 @@
         "express": "4.x",
         "morgan": "1.x",
         "mongodb": "2.x"
+    },
+	"devDependencies":{
+        "mocha": "2.x",
+        "supertest": "1.x"
+    },
+    "scripts": {
+        "test": "./node_modules/mocha/bin/mocha"
     }
 }

--- a/routes/music.js
+++ b/routes/music.js
@@ -19,7 +19,11 @@ var Server = mongo.Server,
 /**
  * @const
  */
-var MUSICDB = 'musicdb';
+var OMPDB = 'omp';
+/**
+ * @const
+ */
+var MUSICCOL = 'musiccol';
 
 /**
  * Use docker image name as the hostname of the mongodb server
@@ -30,10 +34,10 @@ var db = new Db('omp', server);
 
 db.open(function(err, db) {
     if(!err) {
-        console.log("Connected to " + MUSICDB + " database");
-        db.collection(MUSICDB, {strict:true}, function(err, collection) {
+        console.log("Connected to " + OMPDB + " database");
+        db.collection(MUSICCOL, {strict:true}, function(err, collection) {
             if (err) {
-                console.log("The " + MUSICDB + " collection doesn't exist. Creating it with sample data...");
+                console.log("The " + MUSICCOL + " collection doesn't exist. Creating it with sample data...");
                 populateDB();
             }
         });
@@ -45,7 +49,7 @@ db.open(function(err, db) {
  *
  */
 exports.findAll = function(req, res) {
-    db.collection(MUSICDB, function(err, collection) {
+    db.collection(MUSICCOL, function(err, collection) {
         collection.find().toArray(function(err, items) {
             res.send(items);
         });
@@ -60,7 +64,7 @@ exports.findAll = function(req, res) {
 exports.findById = function(req, res) {
     var id = req.params.id;
     console.log('Retrieving songs: ' + id);
-    db.collection(MUSICDB, function(err, collection) {
+    db.collection(MUSICCOL, function(err, collection) {
         collection.findOne({'_id':new BSON.ObjectID(id)}, function(err, item) {
             res.send(item);
         });
@@ -75,7 +79,7 @@ exports.findById = function(req, res) {
 exports.addMusic = function(req, res) {
     var song = req.body;
     console.log('Adding song: ' + JSON.stringify(song));
-    db.collection(MUSICDB, function(err, collection) {
+    db.collection(MUSICCOL, function(err, collection) {
         collection.insert(song, {safe:true}, function(err, result) {
             if (err) {
                 res.send({'error':'An error has occurred'});
@@ -97,7 +101,7 @@ exports.updateMusic = function(req, res) {
     var song = req.body;
     console.log('Updating song: ' + id);
     console.log(JSON.stringify(song));
-    db.collection(MUSICDB, function(err, collection) {
+    db.collection(MUSICCOL, function(err, collection) {
         collection.update({'_id':new BSON.ObjectID(id)}, song, {safe:true}, function(err, result) {
             if (err) {
                 console.log('Error updating song: ' + err);
@@ -118,7 +122,7 @@ exports.updateMusic = function(req, res) {
 exports.deleteMusic = function(req, res) {
     var id = req.params.id;
     console.log('Deleting song: ' + id);
-    db.collection(MUSICDB, function(err, collection) {
+    db.collection(MUSICCOL, function(err, collection) {
         collection.remove({'_id':new BSON.ObjectID(id)}, {safe:true}, function(err, result) {
             if (err) {
                 res.send({'error':'An error has occurred - ' + err});
@@ -157,7 +161,7 @@ var populateDB = function() {
         label: "Apple",
     }];
 
-    db.collection(MUSICDB, function(err, collection) {
+    db.collection(MUSICCOL, function(err, collection) {
         collection.insert(songs, {safe:true}, function(err, result) {});
     });
 

--- a/test/music.js
+++ b/test/music.js
@@ -1,0 +1,26 @@
+/**
+* Testing for music api
+* @author ojourmel
+*
+*/
+var request = require('supertest');
+
+// Connect to an alread running instance of the app
+// This includes are running docker-compose instance
+request = request("http://localhost:3000");
+
+
+describe('music api', function () {
+
+    it('should respond to /music get', function (done) {
+        request
+            .get('/music')
+            .expect('Content-Type', /json/)
+            .expect(200, done);
+    });
+
+    /**
+     * @TODO add other RESTful endpoint tests
+     */
+});
+

--- a/test/static.js
+++ b/test/static.js
@@ -1,0 +1,52 @@
+/**
+* Testing for static files
+* @author ojourmel
+*
+* @see https://glebbahmutov.com/blog/how-to-correctly-unit-test-express-server/
+*/
+var request = require('supertest');
+
+// Connect to an alread running instance of the app
+// This includes are running docker-compose instance
+request = request("http://localhost:3000");
+
+
+describe('static endpoints', function () {
+
+    it('should respond to /player', function (done) {
+        request
+            .get('/player')
+            .expect('Content-Type', /html/)
+            .expect(200, done);
+    });
+    it('should respond to /player/music', function (done) {
+        request
+            .get('/player/music')
+            .expect('Content-Type', /html/)
+            .expect(200, done);
+    });
+    it('should respond to /player/photos', function (done) {
+        request
+            .get('/player/photos')
+            .expect('Content-Type', /html/)
+            .expect(200, done);
+    });
+    it('should respond to /player/tv', function (done) {
+        request
+            .get('/player/tv')
+            .expect('Content-Type', /html/)
+            .expect(200, done);
+    });
+    it('should respond to /player/movies', function (done) {
+        request
+            .get('/player/movies')
+            .expect('Content-Type', /html/)
+            .expect(200, done);
+    });
+
+    it('should 404 everything else', function (done) {
+        request
+            .get('/routes')
+            .expect(404, done);
+    });
+});


### PR DESCRIPTION
- Uses mocha and 'npm test' to run a test suite against
  an _existing_ instance.
- Set up the travis file to build and run the docker-compose
- travis then runs npm test against these container
- While the npm tests are not run _inside_ the docker container,
  and the server/database is not refreshed after each test, this
  allows for local development to easily test things before pushing
  to travis, and as long as tests are written in a commit/rollback
  fashion, then we should be good.
